### PR TITLE
use JS date for missed executions

### DIFF
--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -25,7 +25,7 @@ class Scheduler extends EventEmitter{
             for(let i = missedExecutions-1; i >= 0; i--){
                 const date = new Date(current_time - i * 1000);
                 let date_tmp = this.timeMatcher.apply(date);
-                if(lastExecution.getTime() < date_tmp.getTime() && (i === 0 || this.autorecover) && this.timeMatcher.match(date)){
+                if(Math.floor(lastExecution.getTime()/1000) < Math.floor(date_tmp.getTime()/1000) && (i === 0 || this.autorecover) && this.timeMatcher.match(date)){
                     this.emit('scheduled-time-matched', date_tmp);
                     date_tmp.setMilliseconds(0);
                     lastExecution = date_tmp;


### PR DESCRIPTION
Background:
a function set with JS setTimeout with 1000ms is not always guaranteed to be executed at 1000ms time, we observe that it can be few milli/microseconds earlier sometimes and largely few milli/microseconds later. (refer https://github.com/ridham-vaticlabs/node-cron-forked/blob/v3.0.0/src/scheduler.js#L36)
missedExecutions is used to determine how many seconds has passed from last execution, this used process.hrTime(), as result missedExecutions will be 1 if actual time passed is >=1000ms and 0 is actual time passed is <1000ms (refer https://github.com/ridham-vaticlabs/node-cron-forked/blob/v3.0.0/src/scheduler.js#L24)

process.hrTime is not releted to actual time and datetime can not be infered from process.hrTime.

This library mainly depends on JS new Date(), to match time with expected execution time to determine when a cron is to be executed.

If a time up-to precision of second matches to the pattern passed while creating cron, it executes the trigger function. (refer https://github.com/ridham-vaticlabs/node-cron-forked/blob/v3.0.0/src/scheduler.js#L29, https://github.com/ridham-vaticlabs/node-cron-forked/blob/fbc403930ab3165ffef7d53387a29af92670dfea/src/time-matcher.js#L21)

the library iterates from missed execution to 0 but only runs job for second where i is 0 and above condition is true. (refer https://github.com/ridham-vaticlabs/node-cron-forked/blob/v3.0.0/src/scheduler.js#L26)
it also normlly double executes the job is setTimeout is executed within current seconds again (<1000ms).

Problem:
it can happen that last execution was at x second and 999 millisecond and current execution is at x+2 second and 001 millisecond.
in this scenario actual time passed is ~1002 milliseconds but a second(x+1) is skipped to be checked.
this results in a missed cron trigger if a job was scheduled at x+1 seconds.

to mitigate this problem library has autorecover flag.
this makes timechecking true for any i values at https://github.com/ridham-vaticlabs/node-cron-forked/blob/v3.0.0/src/scheduler.js#L29 provided other condition is true.
however setting autorecover flag as true recovers from possibility of missed execution, but as a side effect it makes normal trigger execution twice. these behaviour are largely undocumented.
mainly because, at the any second x, x-1 and x both are checked with timeMatcher and if a job is scheduled to be executed at X, it will execute at X as well X+1 because of twice checking.

Fix:
the proposed fix uses JS datetime to determine seconds passed instead of process.hrTime, so what this means is if second digit has changes by 2 because of microsecond shifts at border, the variable will be 2, if changes by 1 when missedExecutions will be 1, or 0 is checked in same second.
the for loop will only iterate from missedExecutions-1 to 0 and also checks that at current_time the trigger was not executed in past.
this eliminates duplicate execution every time, as well preserves autorecover flag's expected behaviour.